### PR TITLE
Shared Memory Write and Read performance benchmarking updated based on HCD design changes.

### DIFF
--- a/image processing timing/AssemblyReadBurst.java
+++ b/image processing timing/AssemblyReadBurst.java
@@ -1,0 +1,156 @@
+/**
+ * AssemblyReadBurst
+ *
+ * Burst-mode read timing probe for the Assembly.
+ * Maps ONE burst container file (READ_ONLY) in <= 2 GiB windows and, for each
+ * frame i, reads at byte offset (i * frameBytes) using a single bulk get(...).
+ *
+ * Reports:
+ *   - total copy-only time (sum of get(...) per frame)
+ *   - total end-to-end loop time (position + get + any remaps)
+ *   - total remap time and remap count
+ *   - throughput (GiB/s) for copy-only and end-to-end
+ *
+ * Usage:
+ *   java AssemblyReadBurst <path> <width> <height> <frameCount> [bytesPerPixel=2] [mode=copy|touch]
+ *     path          : absolute path to the burst container file written by HCD test
+ *     width/height  : ROI in pixels (e.g., 1020 1020)
+ *     frameCount    : number of frames in the container
+ *     bytesPerPixel : 1 for 8-bit, 2 for 16-bit (default 2)
+ *     mode          : 'copy' (bulk get into a heap array, default) or 'touch'
+ *                     ('touch' walks pages without copying out, to estimate zero-copy access)
+ *
+ * Notes:
+ *   - No fsync/force(); we measure RAM->RAM path (page cache).
+ *   - Requires frameBytes <= 2e9 (fits in one window). For larger frames, raise WINDOW_BYTES strategy accordingly.
+ */
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+public class AssemblyReadBurst {
+  // Map windows strictly below 2 GiB (MappedByteBuffer is int-indexed)
+  private static final long WINDOW_BYTES = 2_000_000_000L;
+
+  public static void main(String[] args) throws IOException {
+    if (args.length < 4 || args.length > 6) {
+      System.err.println("Usage: java AssemblyReadBurst <path> <width> <height> <frameCount> [bytesPerPixel=2] [mode=copy|touch]");
+      System.exit(2);
+    }
+
+    Path path     = Paths.get(args[0]);
+    int width     = parsePosInt(args[1], "width");
+    int height    = parsePosInt(args[2], "height");
+    int frames    = parsePosInt(args[3], "frameCount");
+    int bpp       = (args.length >= 5) ? parsePosInt(args[4], "bytesPerPixel") : 2;
+    String mode   = (args.length == 6) ? args[5].toLowerCase() : "copy";
+    boolean touch = mode.equals("touch");
+
+    final int  frameBytes     = Math.multiplyExact(Math.multiplyExact(width, height), bpp);
+    if ((long) frameBytes > WINDOW_BYTES) {
+      throw new IllegalArgumentException("frameBytes (" + frameBytes + ") exceeds window size (" + WINDOW_BYTES + ")");
+    }
+    final long containerBytes = Math.multiplyExact((long) frameBytes, (long) frames);
+
+    // Destination for copy mode (reused)
+    final byte[] dst = touch ? null : new byte[frameBytes];
+
+    try (FileChannel ch = FileChannel.open(path, StandardOpenOption.READ)) {
+
+      long windowStart = -1L;         // current mapping window start
+      MappedByteBuffer map = null;
+      int remaps = 0;
+
+      // Warm-up: map first window and do a tiny untimed read to fault pages
+      {
+        long newStart = 0L;
+        int  mapLen   = (int) Math.min(WINDOW_BYTES, containerBytes - newStart);
+        map = ch.map(FileChannel.MapMode.READ_ONLY, newStart, mapLen);
+        windowStart = newStart;
+        map.position(0);
+        if (touch) { map.get(); } else { int len = Math.min(frameBytes, 64); byte[] tmp = new byte[len]; map.get(tmp); }
+        map.position(0);
+      }
+
+      long copyNsTotal     = 0L;
+      long remapNsTotal    = 0L;
+      long endToEndStartNs = System.nanoTime();
+
+      for (int i = 0; i < frames; i++) {
+        long offset = (long) i * frameBytes;
+        long end    = offset + frameBytes;
+
+        // Remap if the frame doesn't fit entirely within current [windowStart, windowStart + cap)
+        boolean needsRemap = (map == null)
+            || (offset < windowStart)
+            || (end > windowStart + (long) map.capacity());
+
+        if (needsRemap) {
+          long newStart = Math.max(0L, end - WINDOW_BYTES);     // ensure whole frame fits
+          int  mapLen   = (int) Math.min(WINDOW_BYTES, containerBytes - newStart);
+
+          long tMap0 = System.nanoTime();
+          map = ch.map(FileChannel.MapMode.READ_ONLY, newStart, mapLen);
+          long tMap1 = System.nanoTime();
+
+          windowStart = newStart;
+          remaps++;
+          remapNsTotal += (tMap1 - tMap0);
+        }
+
+        int srcPos = (int) (offset - windowStart);
+        map.position(srcPos);
+
+        long t0 = System.nanoTime();
+        if (touch) {
+          // Zero-copy: touch every page to simulate streaming access without copying out
+          final int page = 4096;
+          int remaining = frameBytes;
+          int pos = srcPos;
+          byte acc = 0;
+          while (remaining > 0) {
+            acc ^= map.get(pos);                  // read one byte from each page
+            int step = Math.min(page, remaining);
+            pos += step;
+            remaining -= step;
+          }
+          // prevent JVM from optimizing away
+          if (acc == 7) System.out.print("");
+        } else {
+          map.get(dst);                            // ONE bulk read into heap buffer
+        }
+        long t1 = System.nanoTime();
+
+        copyNsTotal += (t1 - t0);
+      }
+
+      long endToEndEndNs = System.nanoTime();
+
+      long   totalBytes      = (long) frames * frameBytes;
+      double totalCopyMs     = copyNsTotal / 1e6;
+      double totalEndToEndMs = (endToEndEndNs - endToEndStartNs) / 1e6;
+      double totalRemapMs    = remapNsTotal / 1e6;
+
+      double giB          = 1024.0 * 1024.0 * 1024.0;
+      double copyGiBs     = (totalBytes / giB) / (copyNsTotal / 1e9);
+      double endToEndGiBs = (totalBytes / giB) / ((endToEndEndNs - endToEndStartNs) / 1e9);
+
+      System.out.printf("Assembly burst read -> %s%n", path.toAbsolutePath());
+      System.out.printf("Config: %dx%d @ %d B/px, %d frames, %,d-byte container, mode=%s%n",
+          width, height, bpp, frames, containerBytes, touch ? "touch" : "copy");
+      System.out.printf("Totals: copy=%.3f ms | end-to-end=%.3f ms | remap=%.3f ms | remaps=%d%n",
+          totalCopyMs, totalEndToEndMs, totalRemapMs, remaps);
+      System.out.printf("Throughput: copy-only=%.2f GiB/s | end-to-end=%.2f GiB/s (%,d bytes total)%n",
+          copyGiBs, endToEndGiBs, totalBytes);
+    }
+  }
+
+  private static int parsePosInt(String s, String name) {
+    int v = Integer.parseInt(s);
+    if (v <= 0) throw new IllegalArgumentException(name + " must be > 0");
+    return v;
+  }
+}

--- a/image processing timing/AssemblyReadSingleShot.java
+++ b/image processing timing/AssemblyReadSingleShot.java
@@ -1,0 +1,102 @@
+/**
+ * AssemblyReadSingleShot
+ *
+ * Single-shot read timing probe for the Assembly.
+ * Maps ONE image file (READ_ONLY) and measures:
+ *   - copy-only: bulk ByteBuffer.get(dst) of the whole frame
+ *   - end-to-end: position + bulk get (no fsync/force), or page-touch loop
+ *
+ * Usage:
+ *   java AssemblyReadSingleShot <path> <width> <height> [bytesPerPixel=2] [mode=copy|touch]
+ *     path          : absolute path to the single-shot container file
+ *     width/height  : ROI in pixels (e.g., 1020 1020)
+ *     bytesPerPixel : 1 for 8-bit, 2 for 16-bit (default 2)
+ *     mode          : 'copy' (default) or 'touch'
+ *
+ * Output:
+ *   - file path/size
+ *   - copy ms, end-to-end ms
+ *   - throughput in GiB/s for copy-only and end-to-end
+ */
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+public class AssemblyReadSingleShot {
+  public static void main(String[] args) throws IOException {
+    if (args.length < 3 || args.length > 5) {
+      System.err.println("Usage: java AssemblyReadSingleShot <path> <width> <height> [bytesPerPixel=2] [mode=copy|touch]");
+      System.exit(2);
+    }
+
+    Path path   = Paths.get(args[0]);
+    int  width  = parsePosInt(args[1], "width");
+    int  height = parsePosInt(args[2], "height");
+    int  bpp    = (args.length >= 4) ? parsePosInt(args[3], "bytesPerPixel") : 2;
+    String mode = (args.length == 5) ? args[4].toLowerCase() : "copy";
+    boolean touch = mode.equals("touch");
+
+    final int frameBytes = Math.multiplyExact(Math.multiplyExact(width, height), bpp);
+    final byte[] dst = touch ? null : new byte[frameBytes];
+
+    try (FileChannel ch = FileChannel.open(path, StandardOpenOption.READ)) {
+      long fileSize = ch.size();
+      if (fileSize < frameBytes) {
+        throw new IllegalArgumentException("File size (" + fileSize + ") < frameBytes (" + frameBytes + ")");
+      }
+      // Map only the frame range from offset 0
+      MappedByteBuffer map = ch.map(FileChannel.MapMode.READ_ONLY, 0, frameBytes);
+
+      // Warm-up: fault a little data (not timed)
+      map.position(0);
+      if (touch) { map.get(); } else { int len = Math.min(frameBytes, 64); byte[] tmp = new byte[len]; map.get(tmp); }
+      map.position(0);
+
+      // Measure end-to-end and copy-only
+      long endToEndStartNs = System.nanoTime();
+      map.position(0); // included in end-to-end
+
+      long t0 = System.nanoTime();
+      if (touch) {
+        // Touch one byte per OS page to simulate zero-copy access
+        final int page = 4096;
+        int remaining = frameBytes;
+        int pos = 0;
+        byte acc = 0;
+        while (remaining > 0) {
+          acc ^= map.get(pos);
+          int step = Math.min(page, remaining);
+          pos += step;
+          remaining -= step;
+        }
+        if (acc == 7) System.out.print(""); // prevent dead-code elim
+      } else {
+        map.get(dst); // ONE bulk read
+      }
+      long t1 = System.nanoTime();
+      long endToEndEndNs = System.nanoTime();
+
+      double copyMs     = (t1 - t0) / 1e6;
+      double end2endMs  = (endToEndEndNs - endToEndStartNs) / 1e6;
+
+      double giB = 1024.0 * 1024.0 * 1024.0;
+      double bytes = frameBytes;
+      double copyGiBs    = (bytes / giB) / ((t1 - t0) / 1e9);
+      double end2endGiBs = (bytes / giB) / ((endToEndEndNs - endToEndStartNs) / 1e9);
+
+      System.out.printf("Assembly single-shot read -> %s (%,d bytes)%n", path.toAbsolutePath(), fileSize);
+      System.out.printf("Config: %dx%d @ %d B/px, mode=%s%n", width, height, bpp, touch ? "touch" : "copy");
+      System.out.printf("Totals: copy=%.3f ms | end-to-end=%.3f ms%n", copyMs, end2endMs);
+      System.out.printf("Throughput: copy-only=%.2f GiB/s | end-to-end=%.2f GiB/s%n", copyGiBs, end2endGiBs);
+    }
+  }
+
+  private static int parsePosInt(String s, String name) {
+    int v = Integer.parseInt(s);
+    if (v <= 0) throw new IllegalArgumentException(name + " must be > 0");
+    return v;
+  }
+}

--- a/image processing timing/MemoryMapWriteBurst.java
+++ b/image processing timing/MemoryMapWriteBurst.java
@@ -1,0 +1,137 @@
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+public class MemoryMapWriteBurst {
+  // Defaults: 1020x1020 @ 16-bit, 1000 frames, /tmp/aps
+  static final int   DEFAULT_WIDTH   = 1020;
+  static final int   DEFAULT_HEIGHT  = 1020;
+  static final int   DEFAULT_BPP     = 2;                 // bytes per pixel (16-bit)
+  static final int   DEFAULT_FRAMES  = 1000;
+
+  // Map windows strictly below 2 GiB (MappedByteBuffer is int-indexed)
+  static final long  WINDOW_BYTES    = 2_000_000_000L;
+
+  public static void main(String[] args) throws IOException {
+    // Usage: java MemoryMapWriteBurst [width height frameCount [outDir] [bytesPerPixel]]
+    if (args.length == 1 || args.length == 2 || args.length > 5) {
+      System.err.println("Usage: java MemoryMapWriteBurst [width height frameCount [outDir] [bytesPerPixel]]");
+      System.exit(2);
+    }
+
+    int  width   = DEFAULT_WIDTH;
+    int  height  = DEFAULT_HEIGHT;
+    int  frames  = DEFAULT_FRAMES;
+    int  bpp     = DEFAULT_BPP;
+    Path outDir  = Paths.get("/tmp", "aps");
+
+    if (args.length >= 3) {
+      width  = parsePosInt(args[0], "width");
+      height = parsePosInt(args[1], "height");
+      frames = parsePosInt(args[2], "frameCount");
+    }
+    if (args.length >= 4) outDir = Paths.get(args[3]);
+    if (args.length == 5) bpp    = parsePosInt(args[4], "bytesPerPixel");
+
+    Files.createDirectories(outDir);
+
+    final int  frameBytes      = Math.multiplyExact(Math.multiplyExact(width, height), bpp);
+    if ((long) frameBytes > WINDOW_BYTES) {
+      throw new IllegalArgumentException("frameBytes (" + frameBytes + ") exceeds window size (" + WINDOW_BYTES + ")");
+    }
+    final long containerBytes  = Math.multiplyExact((long) frameBytes, (long) frames);
+    final Path path            = outDir.resolve(String.format(
+        "burst_container_%dx%d_%dbpp_%dframes.bin", width, height, bpp * 8, frames));
+
+    // Simulated µManager image bytes (reused each frame; contents irrelevant to timing)
+    final byte[] src = new byte[frameBytes];
+
+    try (FileChannel ch = FileChannel.open(
+        path,
+        StandardOpenOption.CREATE, StandardOpenOption.READ,
+        StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+
+      ch.truncate(containerBytes);
+
+      long windowStart = -1L;         // byte offset of current mapping window
+      MappedByteBuffer map = null;
+      int remaps = 0;
+
+      // Warm-up: map first window and do one untimed copy to settle JIT/OS
+      {
+        long newStart = 0L;
+        int  mapLen   = (int) Math.min(WINDOW_BYTES, containerBytes - newStart);
+        map = ch.map(FileChannel.MapMode.READ_WRITE, newStart, mapLen);
+        windowStart = newStart;
+        map.position(0);
+        map.put(src);
+        map.position(0);
+      }
+
+      long copyNsTotal     = 0L;          // sum of per-frame copy times
+      long remapNsTotal    = 0L;          // sum of remap times (mapping only)
+      long endToEndStartNs = System.nanoTime();
+
+      for (int i = 0; i < frames; i++) {
+        long offset = (long) i * frameBytes;
+        long end    = offset + frameBytes;
+
+        // Remap if the frame doesn't fit entirely within current [windowStart, windowStart + cap)
+        boolean needsRemap = (map == null)
+            || (offset < windowStart)
+            || (end > windowStart + (long) map.capacity());
+
+        if (needsRemap) {
+          long newStart = Math.max(0L, end - WINDOW_BYTES);     // window that contains the entire frame
+          int  mapLen   = (int) Math.min(WINDOW_BYTES, containerBytes - newStart);
+
+          long tMap0 = System.nanoTime();
+          map = ch.map(FileChannel.MapMode.READ_WRITE, newStart, mapLen);
+          long tMap1 = System.nanoTime();
+
+          windowStart = newStart;
+          remaps++;
+          remapNsTotal += (tMap1 - tMap0);
+        }
+
+        int dstPos = (int) (offset - windowStart);   // guaranteed >= 0 and <= capacity - frameBytes
+        map.position(dstPos);
+
+        long t0 = System.nanoTime();
+        map.put(src);                                // ONE bulk copy per frame
+        long t1 = System.nanoTime();
+
+        copyNsTotal += (t1 - t0);
+      }
+
+      long endToEndEndNs = System.nanoTime();
+
+      long   totalBytes       = (long) frames * frameBytes;
+      double totalCopyMs      = copyNsTotal / 1e6;
+      double totalEndToEndMs  = (endToEndEndNs - endToEndStartNs) / 1e6;
+      double totalRemapMs     = remapNsTotal / 1e6;
+
+      double giB              = 1024.0 * 1024.0 * 1024.0;
+      double copyGiBs         = (totalBytes / giB) / (copyNsTotal / 1e9);                  // copy-only throughput
+      double endToEndGiBs     = (totalBytes / giB) / ((endToEndEndNs - endToEndStartNs) / 1e9); // loop throughput
+
+      System.out.printf("Burst bulk-copy -> %dx%d @ %d B/px, %d frames, container %,d bytes%n",
+          width, height, bpp, frames, containerBytes);
+      System.out.printf("Path: %s%n", path.toAbsolutePath());
+      System.out.printf("Totals: copy=%.3f ms | end-to-end=%.3f ms | remap=%.3f ms | remaps=%d%n",
+          totalCopyMs, totalEndToEndMs, totalRemapMs, remaps);
+      System.out.printf("Throughput: copy-only=%.2f GiB/s | end-to-end=%.2f GiB/s (%,d bytes total)%n",
+          copyGiBs, endToEndGiBs, totalBytes);
+    }
+  }
+
+  private static int parsePosInt(String s, String name) {
+    int v = Integer.parseInt(s);
+    if (v <= 0) throw new IllegalArgumentException(name + " must be > 0");
+    return v;
+  }
+}

--- a/image processing timing/MemoryMapWriteSingleShot.java
+++ b/image processing timing/MemoryMapWriteSingleShot.java
@@ -1,0 +1,92 @@
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+public class MemoryMapWriteSingleShot {
+  // Defaults: 1020x1020 @ 16-bit
+  static final int DEFAULT_WIDTH = 1020;
+  static final int DEFAULT_HEIGHT = 1020;
+  static final int BYTES_PER_PIXEL = 2; // 16-bit pixels
+
+  static int align4096(int n) { int r = n & 4095; return (r == 0) ? n : (n + (4096 - r)); }
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 1 || args.length > 3) {
+      System.err.println("Usage: java MemoryMapWriteSingleShot [width height [outDir]]");
+      System.exit(2);
+    }
+
+    int width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT;
+    if (args.length >= 2) {
+      try {
+        width = Integer.parseInt(args[0]);
+        height = Integer.parseInt(args[1]);
+        if (width <= 0 || height <= 0) throw new NumberFormatException("non-positive");
+      } catch (NumberFormatException nfe) {
+        System.err.println("Width/height must be positive integers. Got: " + String.join(" ", args));
+        System.exit(2);
+      }
+    }
+
+    // Pick output dir: $TMPDIR/aps (mac preferred) -> /tmp/aps (fallback) unless provided
+    Path outDir;
+    if (args.length == 3) {
+      outDir = Paths.get(args[2]);
+    } else {
+      String tmpEnv = System.getenv("TMPDIR");
+      outDir = (tmpEnv != null && !tmpEnv.isBlank())
+          ? Paths.get(tmpEnv).resolve("aps")
+          : Paths.get("/tmp").resolve("aps");
+    }
+    Files.createDirectories(outDir);
+
+    final int frameBytes  = Math.multiplyExact(Math.multiplyExact(width, height), BYTES_PER_PIXEL);
+    final int mappedBytes = align4096(frameBytes);
+    final Path path = outDir.resolve(
+        String.format("single_shot_%dx%d_%dbpp.bin", width, height, BYTES_PER_PIXEL * 8));
+
+    // Simulated µManager image bytes; contents don’t affect copy timing
+    final byte[] src = new byte[frameBytes];
+
+    try (FileChannel ch = FileChannel.open(
+        path,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.READ,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING)) {
+
+      ch.truncate(mappedBytes);
+      var mbb = ch.map(FileChannel.MapMode.READ_WRITE, 0, mappedBytes);
+
+      // Warm-up (JIT + page touch), not timed
+      mbb.position(0);
+      mbb.put(src);
+      mbb.position(0);
+
+      // Measure end-to-end (position + copy) and copy-only separately
+      long endToEndStartNs = System.nanoTime();
+      mbb.position(0);                      // tiny but included in end-to-end
+      long t0 = System.nanoTime();
+      mbb.put(src);                         // ONE bulk copy
+      long t1 = System.nanoTime();
+      long endToEndEndNs = System.nanoTime();
+
+      double copyMs     = (t1 - t0) / 1_000_000.0;
+      double endToEndMs = (endToEndEndNs - endToEndStartNs) / 1_000_000.0;
+
+      double giB = 1024.0 * 1024.0 * 1024.0;
+      double copyGiBs     = (frameBytes / giB) / ((t1 - t0) / 1e9);
+      double endToEndGiBs = (frameBytes / giB) / ((endToEndEndNs - endToEndStartNs) / 1e9);
+
+      System.out.printf(
+          "Single-shot bulk copy -> %dx%d @ %d B/px => %,d bytes (mapped %,d) -> %s%n",
+          width, height, BYTES_PER_PIXEL, frameBytes, mappedBytes, path.toAbsolutePath());
+      System.out.printf("Totals: copy=%.3f ms | end-to-end=%.3f ms%n", copyMs, endToEndMs);
+      System.out.printf("Throughput: copy-only=%.2f GiB/s | end-to-end=%.2f GiB/s%n",
+          copyGiBs, endToEndGiBs);
+    }
+  }
+}

--- a/image processing timing/MemoryMapWriteSingleShot.java
+++ b/image processing timing/MemoryMapWriteSingleShot.java
@@ -1,3 +1,36 @@
+/**
+ * MemoryMapWriteSingleShot
+ *
+ * Single-shot timing probe for the Detector HCD copy path.
+ * Measures the time to copy ONE image frame into a memory-mapped file
+ * using a single bulk ByteBuffer.put(...). Also reports an “end-to-end”
+ * timing that includes lightweight positioning overhead.
+ *
+ * What it measures:
+ *   - copy-only:   time around mbb.put(src) (pure bulk copy)
+ *   - end-to-end:  position + bulk copy (no mapping or flush)
+ *
+ * Not measured:
+ *   - camera/SDK/µManager delivery latency
+ *   - fsync/force() or disk flushes
+ *
+ * Usage:
+ *   java MemoryMapWriteSingleShot [width height [outDir]]
+ *     width/height: ROI in pixels (default 1020x1020)
+ *     outDir:       output directory (default $TMPDIR/aps or /tmp/aps)
+ *   Assumes 16-bit pixels (2 B/px). Adjust in code if needed.
+ *
+ * Output:
+ *   - path of the mapped file
+ *   - frame size in bytes (and mapped length)
+ *   - copy-only ms, end-to-end ms
+ *   - throughput in GiB/s for both timings
+ *
+ * Notes:
+ *   - The file is created/truncated once and mapped once (size = frame bytes).
+ *   - No per-pixel loops; a single bulk copy reflects HCD behaviour.
+ */
+
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;


### PR DESCRIPTION
The new classes are:
MemoryMapWriteSingleShot [width height [outDir] [bytesPerPixel]]
MemoryMapWriteBurst [width height frameCount [outDir] [bytesPerPixel]]
AssemblyReadSingleShot <path> <width> <height> [bytesPerPixel=2] [mode=copy|touch]
AssemblyReadBurst <path> <width> <height> <frameCount> [bytesPerPixel=2] [mode=copy|touch]